### PR TITLE
remove UI ids

### DIFF
--- a/models/sql_models.py
+++ b/models/sql_models.py
@@ -16,7 +16,7 @@ class PortfolioProject(SQLModel, table=True):
     __table_args__ = {"schema": schema_name}
     prosjekt_sk_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     prosjekt_id: uuid.UUID
     navn: str | None = None
@@ -36,7 +36,7 @@ class DigitaliseringStrategi(SQLModel, table=True):
 
     digitalisering_strategi_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     sammenheng_digital_strategi: str | None = None
     digital_strategi_kommentar: str | None = None
@@ -54,7 +54,7 @@ class Finansiering(SQLModel, table=True):
 
     finansering_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     
     potensiell_finansering: int | None = None
@@ -81,7 +81,7 @@ class Fremskritt(SQLModel, table=True):
 
     fremskritt_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     fremskritt: str | None = None
     fase: str | None = None
@@ -100,7 +100,7 @@ class Malbilde(SQLModel, table=True):
 
     malbilde_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     malbilde_1_beskrivelse: str | None = None
     malbilde_1_vurdering: str | None = None
@@ -123,7 +123,7 @@ class Problemstilling(SQLModel, table=True):
 
     problem_stilling_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     problem: str | None = None
     sist_endret: datetime | None = None
@@ -139,7 +139,7 @@ class Resursbehov(SQLModel, table=True):
 
     ressursbehov_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     estimert_budsjet_forklaring: str | None = None
     estimert_budsjet_behov: int | None = None
@@ -163,7 +163,7 @@ class Ressursbruk(SQLModel, table=True):
 
     ressursbruk_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     year: int | None = None
     predicted_resources: int | None = None
@@ -181,7 +181,7 @@ class Risikovurdering(SQLModel, table=True):
 
     risiko_vurdering_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     vurdering: str | None = None
     sist_endret: datetime | None = None
@@ -197,7 +197,7 @@ class Samarabeid(SQLModel, table=True):
 
     samarbeid_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     samarbeid_intern: str | None = None
     samarbeid_eksternt: str | None = None
@@ -215,7 +215,7 @@ class Tiltak(SQLModel, table=True):
 
     tiltak_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     tiltak_beskrivelse: str | None = None
     sist_endret: datetime | None = None
@@ -231,7 +231,7 @@ class UnderstøtteTildelingsbrev(SQLModel, table=True):
 
     strategisk_forankring_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     mål_1_beskrivelse: str | None = None
     mål_2_beskrivelse: str | None = None
@@ -252,7 +252,7 @@ class Vurdering(SQLModel, table=True):
 
     vurdering_id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
-        sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+        sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
     )
     gruppe: str | None = None
     pulje: int | None = None
@@ -269,7 +269,7 @@ class Overview(SQLModel, table=True):
     __table_args__ = {"schema": schema_name}
     prosjekt_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     navn: str | None = None
     avdeling: str | None = None
@@ -290,7 +290,7 @@ class DeliveryRisk(SQLModel, table = True):
     __table_args__ = {"schema": schema_name}
     delivery_risk: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     prosjekt_id: uuid.UUID = Field(
         foreign_key=f"{schema_name}.PortfolioProject.prosjekt_id",
@@ -307,7 +307,7 @@ class Avhengigheter(SQLModel, table = True):
     __table_args__ = {"schema": schema_name}
     avhengigheter_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     prosjekt_id: uuid.UUID = Field(
         foreign_key=f"{schema_name}.PortfolioProject.prosjekt_id",
@@ -324,7 +324,7 @@ class SamfunnsEffekt(SQLModel, table = True):
 
     samfunnseffekt_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     prosjekt_id : uuid.UUID | None = None
     effekt: str | None
@@ -337,7 +337,7 @@ class Rapportering(SQLModel, table = True):
     __table_args__ = {"schema": schema_name}
     rapporterings_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     prosjekt_id: uuid.UUID = Field(
         foreign_key=f"{schema_name}.PortfolioProject.prosjekt_id",
@@ -382,7 +382,7 @@ class OpenOverview(SQLModel, table = True):
     __table_args__ = {"schema": schema_name}
     prosjekt_id: uuid.UUID = Field(
             default_factory=uuid.uuid4,
-            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True, default=uuid.uuid4),
+            sa_column=Column(UNIQUEIDENTIFIER, primary_key=True),
         )
     navn: str | None = None
     avdeling: str | None = None

--- a/models/ui_models.py
+++ b/models/ui_models.py
@@ -9,7 +9,6 @@ from models.validators import to_datetime, convert_to_int
 
 
 class PortfolioProjectUI(BaseModel):
-    prosjekt_sk_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     navn: str | None = None
     oppstart: Annotated[datetime | None, BeforeValidator(to_datetime)] = None
@@ -23,7 +22,6 @@ class PortfolioProjectUI(BaseModel):
 
 
 class DigitaliseringStrategiUI(BaseModel):
-    digitalisering_strategi_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     sammenheng_digital_strategi: str | None = None
     digital_strategi_kommentar: str | None = None
@@ -33,7 +31,6 @@ class DigitaliseringStrategiUI(BaseModel):
 
 
 class FinansieringUI(BaseModel):
-    finansering_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     potensiell_finansering: int | None = None
     mnd_verk: int | None = None
@@ -51,7 +48,6 @@ class FinansieringUI(BaseModel):
     
 
 class FremskrittUI(BaseModel):
-    fremskritt_id: uuid.UUID = uuid.uuid4()
     rapporterings_id: uuid.UUID | None = None
     prosjekt_id: uuid.UUID | None = None
     fremskritt: str | None = None
@@ -64,7 +60,6 @@ class FremskrittUI(BaseModel):
 
 
 class MalbildeUI(BaseModel):
-    malbilde_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     malbilde_1_beskrivelse: str | None = None
     malbilde_1_vurdering: str | None = None
@@ -79,7 +74,6 @@ class MalbildeUI(BaseModel):
     er_gjeldende: bool = True
 
 class ProblemstillingUI(BaseModel):
-    problem_stilling_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     problem: str | None = None
     sist_endret: datetime | None = None
@@ -88,7 +82,6 @@ class ProblemstillingUI(BaseModel):
 
 
 class ResursbehovUI(BaseModel):
-    ressursbehov_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     estimert_budsjet_forklaring: str | None = None
     estimert_budsjet_behov: Annotated[int | None, BeforeValidator(convert_to_int)] = None
@@ -105,7 +98,6 @@ class ResursbehovUI(BaseModel):
 
 
 class RessursbrukUI(BaseModel):
-    ressursbruk_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     year: int | None = None
     predicted_resources: Annotated[int | None, BeforeValidator(convert_to_int)] = None
@@ -114,7 +106,6 @@ class RessursbrukUI(BaseModel):
     er_gjeldende: bool = True
 
 class RisikovurderingUI(BaseModel):
-    risiko_vurdering_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     vurdering: str | None = None
     sist_endret: datetime | None = None
@@ -123,7 +114,6 @@ class RisikovurderingUI(BaseModel):
 
 
 class SamarabeidUI(BaseModel):
-    samarbeid_id: uuid.UUID = uuid.uuid4() 
     prosjekt_id : uuid.UUID | None = None
     samarbeid_intern: str | None = None
     samarbeid_eksternt: str | None = None
@@ -133,7 +123,6 @@ class SamarabeidUI(BaseModel):
     er_gjeldende: bool = True
 
 class TiltakUI(BaseModel):
-    tiltak_id: uuid.UUID = uuid.uuid4()
     prosjekt_id : uuid.UUID | None = None
     tiltak_beskrivelse: str | None = None
     sist_endret: datetime | None = None
@@ -141,7 +130,6 @@ class TiltakUI(BaseModel):
     er_gjeldende: bool = True
 
 class VurderingUI(BaseModel):
-    vurdering_id: uuid.UUID = uuid.uuid4()
     prosjekt_id : uuid.UUID | None = None
     gruppe: str | None = None
     pulje: int | None = None
@@ -151,7 +139,6 @@ class VurderingUI(BaseModel):
     er_gjeldende: bool = True
 
 class SamfunnsEffektUI(BaseModel):
-    samfunnseffekt_id: uuid.UUID = uuid.uuid4()
     prosjekt_id : uuid.UUID | None = None
     effekt: str | None = None
     sist_endret: datetime | None = None
@@ -159,7 +146,6 @@ class SamfunnsEffektUI(BaseModel):
     er_gjeldende: bool = True
 
 class RisikoUI(BaseModel):
-    risiko_id: uuid.UUID = uuid.uuid4()
     prosjekt_id : uuid.UUID | None = None
     risiko: str | None = None
     sist_endret: datetime | None = None
@@ -219,22 +205,18 @@ class OverviewUI(BaseModel):
     estimert_bruk_2028: int | None = None   
 
 class DeliveryRiskUI(BaseModel):
-    delivery_risk: uuid.UUID = uuid.uuid4()
-    rapporterings_id: uuid.UUID | None = None
     risiko_rapportert: str | None = None
     risiko_rapportert_begrunnet: str | None = None
     endret_av: str | None = None
     er_gjeldende: bool = True
 
 class AvhengigheterUI(BaseModel):
-    avhengigheter_id: uuid.UUID = uuid.uuid4()
     prosjekt_id: uuid.UUID | None = None
     avhengigheter: str | None = None
     endret_av: str | None = None
     er_gjeldende: bool = True
 
 class RapporteringUI(BaseModel):
-    rapporterings_id: uuid.UUID = uuid.uuid4() 
     prosjekt_id: uuid.UUID | None = None
     viktige_endringer: str | None = None
     viktige_endringer_kommentar: str | None = None


### PR DESCRIPTION
Fiks: Ikke unike UUID for alle nye databaserader

Alle nye rader fikk samme UUID ved oppdatering av prosjektdata. Kun prosjekt_id fungerte korrekt.

UI-modellene inneholdt uuid-felt som ble serialisert via model_dump() og sendt videre til SQL-modellene i ui_to_sqlmodel(). Dette overskrev default_factory=uuid.uuid4, slik at samme UUID ble gjenbrukt på tvers av rader.
Løsning

Fjernet alle uuid fra UI-modellene, siden disse kun er relevante i databaselaget. UI model trenger ingen unique id. 
default_factory=uuid.uuid4 får nå ansvar for å generere ny unik UUID for hver ny rad, slik tiltenkt.
